### PR TITLE
Fix regression in formatting by using global logger

### DIFF
--- a/jenkins/crawler_test.go
+++ b/jenkins/crawler_test.go
@@ -89,7 +89,7 @@ func Test_ExtractBuildLogs(t *testing.T) {
 }
 
 func Test_PrintBuildLog(t *testing.T) {
-	hook := test.NewLocal(c.log)
+	hook := test.NewGlobal()
 
 	var jlogs []*ale.Log
 	loadFixture(t, "extracted_build_logs.json", &jlogs)

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/sirupsen/logrus"
 	"github.com/alde/ale/config"
+	"github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
#10 introduced a regression in the log formatting by using a shared instance of a logger for testability purposes ( `c.log.*`). But that that logger didn't use the configuration, like JSON formatting the log output.

This PR reverts to using the global logger again (`logrus.*`) while still having testability using the other decorator `test.NewGlobal()`.