### PR TITLE
Output raw log line without JSON marshalling

### DIFF
--- a/jenkins/crawler.go
+++ b/jenkins/crawler.go
@@ -78,14 +78,11 @@ func (c *Crawler) logBuildLogs(buildID string, uri *url.URL) {
 }
 
 func (c *Crawler) printBuildLog(jlog *ale.Log, uri *url.URL, buildID string) {
-	jsonData, err := json.Marshal(jlog)
-	if err != nil {
-		logrus.WithError(err).Error("unable to parse log entry")
-	}
 	logrus.WithFields(logrus.Fields{
-		"uri":      uri.String(),
-		"build_id": buildID,
-	}).Info(string(jsonData))
+		"uri":             uri.String(),
+		"build_id":        buildID,
+		"build_timestamp": jlog.TimeStamp,
+	}).Info(jlog.Line)
 }
 
 func (c *Crawler) extractBuildLogs(jdata *ale.JenkinsData) []*ale.Log {

--- a/jenkins/crawler_test.go
+++ b/jenkins/crawler_test.go
@@ -104,9 +104,7 @@ func Test_PrintBuildLog(t *testing.T) {
 	assert.Equal(t, logrus.InfoLevel, hook.LastEntry().Level)
 	for idx, entry := range hook.AllEntries() {
 		expected := jlogs[idx]
-		var actual *ale.Log
-		_ = json.Unmarshal([]byte(entry.Message), &actual)
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, expected.Line, entry.Message)
 	}
 	hook.Reset()
 	assert.Nil(t, hook.LastEntry())


### PR DESCRIPTION
This PR refactors `printBuildLog` to not marshal `TimeStamp` + `Line` together, rather outputting the raw log line instead and putting the timestamp as a separate log field.